### PR TITLE
Builder.io: Add synthwave theme with new page and components

### DIFF
--- a/app/[...page]/dummyNav.tsx
+++ b/app/[...page]/dummyNav.tsx
@@ -1,13 +1,14 @@
 /* eslint-disable @next/next/no-img-element */
-import * as React from 'react';
-import Logo from '/app/logo.svg';
-import User from './usericon.svg';
+import * as React from "react";
+import Logo from "/app/logo.svg";
+import User from "./usericon.svg";
 
 const navigationItems = [
-  { href: '#', label: 'Home' },
-  { href: '#', label: 'Features' },
-  { href: '#', label: 'About' },
-  { href: '#', label: 'Contact' },
+  { href: "/", label: "Home" },
+  { href: "/synthwave", label: "Synthwave" },
+  { href: "#", label: "Features" },
+  { href: "#", label: "About" },
+  { href: "#", label: "Contact" },
 ];
 
 interface NavigationLinkProps {
@@ -31,18 +32,11 @@ export const Navigation: React.FC = () => {
   return (
     <nav className="box-border flex justify-between items-center px-8 py-4 w-full bg-gray-50">
       <div className="flex items-center">
-        <img
-          src={Logo.src}
-          alt="Company Brand Logo"
-          className="h-10"
-        />
+        <img src={Logo.src} alt="Company Brand Logo" className="h-10" />
       </div>
       <div className="flex gap-8 items-center">
         {navigationItems.map((item) => (
-          <NavigationLink
-            key={item.label}
-            href={item.href}
-          >
+          <NavigationLink key={item.label} href={item.href}>
             {item.label}
           </NavigationLink>
         ))}
@@ -51,11 +45,7 @@ export const Navigation: React.FC = () => {
         className="flex items-center p-2 cursor-pointer border-none bg-slate-200 rounded-md"
         aria-label="User Profile"
       >
-        <img
-          src={User.src}
-          alt=""
-          className="w-6 h-6"
-        />
+        <img src={User.src} alt="" className="w-6 h-6" />
       </button>
     </nav>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,21 +1,31 @@
+"use client";
 import Image from "next/image";
+import { SynthwaveBackground } from "@/components/synthwave/SynthwaveBackground";
+import { GlowText } from "@/components/synthwave/GlowText";
+import styles from "@/components/synthwave/styles.module.css";
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-between p-24">
+    <main className="flex min-h-screen flex-col items-center justify-between p-24 bg-[#0d0221] text-white relative overflow-hidden">
+      <SynthwaveBackground />
+
       <div className="z-10 w-full max-w-5xl items-center justify-between font-mono text-sm lg:flex">
-        <p className="fixed left-0 top-0 flex w-full justify-center border-b border-gray-300 bg-gradient-to-b from-zinc-200 pb-6 pt-8 backdrop-blur-2xl dark:border-neutral-800 dark:bg-zinc-800/30 dark:from-inherit lg:static lg:w-auto  lg:rounded-xl lg:border lg:bg-gray-200 lg:p-4 lg:dark:bg-zinc-800/30">
-          Get started by editing&nbsp;
-          <code className="font-mono font-bold">app/page.tsx</code>
+        <p className="fixed left-0 top-0 flex w-full justify-center border-b border-[#ff00ff]/30 bg-gradient-to-b from-[#1a0033] pb-6 pt-8 backdrop-blur-2xl lg:static lg:w-auto lg:rounded-xl lg:border lg:bg-[#1a0033]/30 lg:p-4">
+          <span className={styles.neonBlueText}>
+            Get started by editing&nbsp;
+          </span>
+          <code className={`font-mono font-bold ${styles.neonPinkText}`}>
+            app/page.tsx
+          </code>
         </p>
-        <div className="fixed bottom-0 left-0 flex h-48 w-full items-end justify-center bg-gradient-to-t from-white via-white dark:from-black dark:via-black lg:static lg:size-auto lg:bg-none">
+        <div className="fixed bottom-0 left-0 flex h-48 w-full items-end justify-center bg-gradient-to-t from-[#0d0221] via-[#0d0221] lg:static lg:size-auto lg:bg-none">
           <a
             className="pointer-events-none flex place-items-center gap-2 p-8 lg:pointer-events-auto lg:p-0"
             href="https://vercel.com?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
             target="_blank"
             rel="noopener noreferrer"
           >
-            By{" "}
+            <span className={styles.neonPinkText}>By</span>
             <Image
               src="/vercel.svg"
               alt="Vercel Logo"
@@ -28,7 +38,14 @@ export default function Home() {
         </div>
       </div>
 
-      <div className="relative z-[-1] flex place-items-center before:absolute before:h-[300px] before:w-full before:-translate-x-1/2 before:rounded-full before:bg-gradient-radial before:from-white before:to-transparent before:blur-2xl before:content-[''] after:absolute after:-z-20 after:h-[180px] after:w-full after:translate-x-1/3 after:bg-gradient-conic after:from-sky-200 after:via-blue-200 after:blur-2xl after:content-[''] before:dark:bg-gradient-to-br before:dark:from-transparent before:dark:to-blue-700 before:dark:opacity-10 after:dark:from-sky-900 after:dark:via-[#0141ff] after:dark:opacity-40 sm:before:w-[480px] sm:after:w-[240px] before:lg:h-[360px]">
+      <div className="relative z-[1] flex flex-col items-center">
+        <GlowText
+          text="HELLO WORLD"
+          mainColor="#ff00ff"
+          shadowColor="#00ffff"
+          className="text-6xl md:text-8xl font-bold tracking-wider mb-6"
+        />
+
         <Image
           className="relative dark:drop-shadow-[0_0_0.3rem_#ffffff70] dark:invert"
           src="/next.svg"
@@ -42,68 +59,68 @@ export default function Home() {
       <div className="mb-32 grid text-center lg:mb-0 lg:w-full lg:max-w-5xl lg:grid-cols-4 lg:text-left">
         <a
           href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
+          className="group rounded-lg border border-[#ff00ff]/30 px-5 py-4 transition-colors hover:border-[#ff00ff] hover:bg-[#ff00ff]/10"
           target="_blank"
           rel="noopener noreferrer"
         >
-          <h2 className="mb-3 text-2xl font-semibold">
+          <h2 className={`mb-3 text-2xl font-semibold ${styles.neonPinkText}`}>
             Docs{" "}
             <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
               -&gt;
             </span>
           </h2>
-          <p className="m-0 max-w-[30ch] text-sm opacity-50">
+          <p className="m-0 max-w-[30ch] text-sm opacity-70">
             Find in-depth information about Next.js features and API.
           </p>
         </a>
 
         <a
           href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
+          className="group rounded-lg border border-[#00ffff]/30 px-5 py-4 transition-colors hover:border-[#00ffff] hover:bg-[#00ffff]/10"
           target="_blank"
           rel="noopener noreferrer"
         >
-          <h2 className="mb-3 text-2xl font-semibold">
+          <h2 className={`mb-3 text-2xl font-semibold ${styles.neonBlueText}`}>
             Learn{" "}
             <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
               -&gt;
             </span>
           </h2>
-          <p className="m-0 max-w-[30ch] text-sm opacity-50">
+          <p className="m-0 max-w-[30ch] text-sm opacity-70">
             Learn about Next.js in an interactive course with&nbsp;quizzes!
           </p>
         </a>
 
         <a
           href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
+          className="group rounded-lg border border-[#ff00ff]/30 px-5 py-4 transition-colors hover:border-[#ff00ff] hover:bg-[#ff00ff]/10"
           target="_blank"
           rel="noopener noreferrer"
         >
-          <h2 className="mb-3 text-2xl font-semibold">
+          <h2 className={`mb-3 text-2xl font-semibold ${styles.neonPinkText}`}>
             Templates{" "}
             <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
               -&gt;
             </span>
           </h2>
-          <p className="m-0 max-w-[30ch] text-sm opacity-50">
+          <p className="m-0 max-w-[30ch] text-sm opacity-70">
             Explore starter templates for Next.js.
           </p>
         </a>
 
         <a
           href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
+          className="group rounded-lg border border-[#00ffff]/30 px-5 py-4 transition-colors hover:border-[#00ffff] hover:bg-[#00ffff]/10"
           target="_blank"
           rel="noopener noreferrer"
         >
-          <h2 className="mb-3 text-2xl font-semibold">
+          <h2 className={`mb-3 text-2xl font-semibold ${styles.neonBlueText}`}>
             Deploy{" "}
             <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
               -&gt;
             </span>
           </h2>
-          <p className="m-0 max-w-[30ch] text-balance text-sm opacity-50">
+          <p className="m-0 max-w-[30ch] text-balance text-sm opacity-70">
             Instantly deploy your Next.js site to a shareable URL with Vercel.
           </p>
         </a>

--- a/app/synthwave/page.tsx
+++ b/app/synthwave/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+import React from "react";
+import { Navigation } from "../[...page]/dummyNav";
+import { Footer } from "@/components/footer/Footer";
+import { SynthwaveBackground } from "@/components/synthwave/SynthwaveBackground";
+import { GlowText } from "@/components/synthwave/GlowText";
+
+export default function SynthwavePage() {
+  return (
+    <div className="flex flex-col min-h-[100dvh]">
+      <Navigation />
+      <main className="grow relative overflow-hidden bg-[#0d0221] flex items-center justify-center">
+        <SynthwaveBackground />
+        <div className="z-10 text-center py-24 px-4">
+          <GlowText
+            text="HELLO WORLD"
+            mainColor="#ff00ff"
+            shadowColor="#00ffff"
+            className="text-6xl md:text-8xl font-bold tracking-wider mb-6"
+          />
+          <p className="text-purple-300 text-xl md:text-2xl max-w-2xl mx-auto">
+            Welcome to the neon grid of tomorrow, where the digital dawn never
+            ends.
+          </p>
+          <div className="mt-10">
+            <button className="px-6 py-3 bg-transparent border-2 border-[#ff00ff] text-[#ff00ff] hover:bg-[#ff00ff]/20 transition-all duration-300 rounded-lg font-bold tracking-wider mx-2">
+              EXPLORE
+            </button>
+            <button className="px-6 py-3 bg-transparent border-2 border-[#00ffff] text-[#00ffff] hover:bg-[#00ffff]/20 transition-all duration-300 rounded-lg font-bold tracking-wider mx-2">
+              CONNECT
+            </button>
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/components/synthwave/GlowText.tsx
+++ b/components/synthwave/GlowText.tsx
@@ -1,0 +1,37 @@
+"use client";
+import React from "react";
+import styles from "./styles.module.css";
+
+interface GlowTextProps {
+  text: string;
+  mainColor?: string;
+  shadowColor?: string;
+  className?: string;
+  animate?: boolean;
+}
+
+export const GlowText: React.FC<GlowTextProps> = ({
+  text,
+  mainColor = "#ff00ff",
+  shadowColor = "#00ffff",
+  className = "",
+  animate = true,
+}) => {
+  const textStyle = {
+    color: mainColor,
+    textShadow: `0 0 5px ${mainColor}, 
+                0 0 10px ${mainColor}, 
+                0 0 20px ${mainColor}, 
+                0 0 40px ${shadowColor}, 
+                0 0 80px ${shadowColor}`,
+  };
+
+  return (
+    <h1
+      className={`${animate ? styles.flickerAnimation : ""} ${className}`}
+      style={textStyle}
+    >
+      {text}
+    </h1>
+  );
+};

--- a/components/synthwave/SynthwaveBackground.tsx
+++ b/components/synthwave/SynthwaveBackground.tsx
@@ -1,0 +1,54 @@
+"use client";
+import React from "react";
+import styles from "./styles.module.css";
+
+interface SynthwaveBackgroundProps {
+  gridColor?: string;
+  sunColor?: string;
+}
+
+export const SynthwaveBackground: React.FC<SynthwaveBackgroundProps> = ({
+  gridColor = "rgba(255, 0, 255, 0.5)",
+  sunColor = "linear-gradient(to top, #ff8a00, #ff0080)",
+}) => {
+  return (
+    <div className={styles.synthwaveContainer}>
+      <div
+        className={styles.sun}
+        style={{
+          background: sunColor,
+        }}
+      />
+      <div
+        className={styles.grid}
+        style={{
+          backgroundImage: `linear-gradient(${gridColor} 1px, transparent 1px), 
+                            linear-gradient(90deg, ${gridColor} 1px, transparent 1px)`,
+        }}
+      />
+      <div className={styles.mountains}>
+        <div
+          className={styles.mountain}
+          style={{ left: "10%", height: "180px" }}
+        />
+        <div
+          className={styles.mountain}
+          style={{ left: "30%", height: "240px" }}
+        />
+        <div
+          className={styles.mountain}
+          style={{ left: "50%", height: "280px" }}
+        />
+        <div
+          className={styles.mountain}
+          style={{ left: "70%", height: "220px" }}
+        />
+        <div
+          className={styles.mountain}
+          style={{ left: "90%", height: "160px" }}
+        />
+      </div>
+      <div className={styles.stars} />
+    </div>
+  );
+};

--- a/components/synthwave/styles.module.css
+++ b/components/synthwave/styles.module.css
@@ -1,0 +1,113 @@
+.synthwaveContainer {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  perspective: 1000px;
+}
+
+.grid {
+  position: absolute;
+  bottom: 0;
+  width: 150%;
+  height: 100%;
+  background-size: 50px 50px;
+  background-position-y: 0px;
+  transform: rotateX(60deg) translateZ(0) translateY(50%);
+  animation: gridMove 15s linear infinite;
+  transform-origin: center;
+  backface-visibility: hidden;
+}
+
+.sun {
+  position: absolute;
+  width: 300px;
+  height: 300px;
+  border-radius: 50%;
+  top: 30%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  box-shadow:
+    0 0 50px #ff8a00,
+    0 0 100px #ff0080;
+  z-index: 1;
+}
+
+.mountains {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 30%;
+  z-index: 2;
+}
+
+.mountain {
+  position: absolute;
+  bottom: 0;
+  width: 200px;
+  background: linear-gradient(to top, #1a0033, #3d0066);
+  clip-path: polygon(0 100%, 50% 0, 100% 100%);
+  transform: translateX(-50%);
+}
+
+.stars {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 50%;
+  background-image:
+    radial-gradient(2px 2px at 20px 30px, #ffffff, rgba(0, 0, 0, 0)),
+    radial-gradient(2px 2px at 40px 70px, #ffffff, rgba(0, 0, 0, 0)),
+    radial-gradient(2px 2px at 50px 160px, #ffffff, rgba(0, 0, 0, 0)),
+    radial-gradient(2px 2px at 90px 40px, #ffffff, rgba(0, 0, 0, 0)),
+    radial-gradient(2px 2px at 130px 80px, #ffffff, rgba(0, 0, 0, 0)),
+    radial-gradient(2px 2px at 160px 120px, #ffffff, rgba(0, 0, 0, 0));
+  background-repeat: repeat;
+  background-size: 200px 200px;
+}
+
+.flickerAnimation {
+  animation: textFlicker 4s infinite alternate;
+}
+
+@keyframes gridMove {
+  0% {
+    background-position: 0 0;
+  }
+  100% {
+    background-position: 0 50px;
+  }
+}
+
+@keyframes textFlicker {
+  0%,
+  19.999%,
+  22%,
+  62.999%,
+  64%,
+  64.999%,
+  70%,
+  100% {
+    opacity: 1;
+  }
+  20%,
+  21.999%,
+  63%,
+  63.999%,
+  65%,
+  69.999% {
+    opacity: 0.8;
+  }
+}
+
+@media (max-width: 768px) {
+  .grid {
+    background-size: 30px 30px;
+  }
+
+  .sun {
+    width: 200px;
+    height: 200px;
+  }
+}

--- a/components/synthwave/styles.module.css
+++ b/components/synthwave/styles.module.css
@@ -4,6 +4,7 @@
   height: 100%;
   overflow: hidden;
   perspective: 1000px;
+  z-index: -2;
 }
 
 .grid {
@@ -99,6 +100,81 @@
   69.999% {
     opacity: 0.8;
   }
+}
+
+.synthwaveButton {
+  background-color: transparent;
+  border: 2px solid;
+  border-radius: 8px;
+  padding: 8px 20px;
+  font-weight: bold;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  transition: all 0.3s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.synthwaveButton:before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.2),
+    transparent
+  );
+  transition: all 0.5s ease;
+}
+
+.synthwaveButton:hover:before {
+  left: 100%;
+}
+
+.neonPink {
+  color: #ff00ff;
+  border-color: #ff00ff;
+  text-shadow: 0 0 5px #ff00ff;
+  box-shadow: 0 0 10px rgba(255, 0, 255, 0.5);
+}
+
+.neonPink:hover {
+  background-color: rgba(255, 0, 255, 0.1);
+  box-shadow: 0 0 15px rgba(255, 0, 255, 0.8);
+}
+
+.neonBlue {
+  color: #00ffff;
+  border-color: #00ffff;
+  text-shadow: 0 0 5px #00ffff;
+  box-shadow: 0 0 10px rgba(0, 255, 255, 0.5);
+}
+
+.neonBlue:hover {
+  background-color: rgba(0, 255, 255, 0.1);
+  box-shadow: 0 0 15px rgba(0, 255, 255, 0.8);
+}
+
+.neonText {
+  font-weight: bold;
+}
+
+.neonPinkText {
+  color: #ff00ff;
+  text-shadow:
+    0 0 5px #ff00ff,
+    0 0 10px #ff00ff;
+}
+
+.neonBlueText {
+  color: #00ffff;
+  text-shadow:
+    0 0 5px #00ffff,
+    0 0 10px #00ffff;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
This PR adds a synthwave-themed styling to the application with the following changes:

1. Created new synthwave components:
   - SynthwaveBackground: Creates a retro grid background with sun and mountains
   - GlowText: Renders text with neon glow effects
   - Added corresponding styles in a module CSS file

2. Updated the home page with synthwave styling and visual elements

3. Added a dedicated synthwave page route

4. Updated navigation links to include the new synthwave page

All components are client-side rendered with the "use client" directive.

tag @builderio-bot for anything you want the bot to do


<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a06e355202b5497eba0fa369ada11458</projectId>-->